### PR TITLE
Change nonce expiry time checking

### DIFF
--- a/WPSimpleNonce.php
+++ b/WPSimpleNonce.php
@@ -69,7 +69,7 @@ Class WPSimpleNonce {
 		
 		self::deleteNonce($name);
 		
-		if ($nonceExpires<time()+86400) {
+		if ($nonceExpires<time()) {
 			$returnValue = null;
 		}
 


### PR DESCRIPTION
The nonce was expiring practically instantly, as fetchNonce was checking if the expiry time was less than time() + 86400.
